### PR TITLE
Swap tslint exclusions with eslint ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ where
     * `cpp` : C++
     * `cs` : C#
     * `py` : Python
-    * `ts` : Typescript
+    * `ts` : TypeScript
     * `go` : Go
      
 `java` is the default value if no language is specified.

--- a/ts/codec-template.ts.j2
+++ b/ts/codec-template.ts.j2
@@ -76,7 +76,7 @@
  * limitations under the License.
  */
 
-/*tslint:disable:max-line-length*/
+/* eslint-disable max-len */
 import {BitsUtil} from '../BitsUtil';
 {% if request_fix_sized_params|length != 0 or response_fix_sized_params|length != 0 or event_fix_sized_params|length != 0 %}
 import {FixSizedTypesCodec} from './builtin/FixSizedTypesCodec';

--- a/ts/custom-codec-template.ts.j2
+++ b/ts/custom-codec-template.ts.j2
@@ -62,7 +62,7 @@
  * limitations under the License.
  */
 
-/*tslint:disable:max-line-length*/
+/* eslint-disable max-len */
 {% if fix_sized_params|length != 0 %}
 import {FixSizedTypesCodec} from '../builtin/FixSizedTypesCodec';
 import {BitsUtil} from '../../BitsUtil';


### PR DESCRIPTION
As https://github.com/hazelcast/hazelcast-nodejs-client/pull/553 swaps tslint with eslint, we need to update exclusions